### PR TITLE
Add folder tags from C++ code to determine attribute's default collapsed state

### DIFF
--- a/SyncAttribute.C
+++ b/SyncAttribute.C
@@ -106,7 +106,10 @@ CreateAttrOperation::pushFolder(const HAPI_ParmInfo& parmInfo)
 
         attrFn->create(attrName, attrName);
         attrFn->setNiceNameOverride(niceName);
-
+        if (attrName.indexW("__open__") == -1)
+        {
+            attrFn->addToCategory("default_close");
+        }
         /*std::vector<MString> tagNames;
         std::vector<MString> tagValues;
 

--- a/scripts/AEhoudiniAssetTemplate.mel
+++ b/scripts/AEhoudiniAssetTemplate.mel
@@ -532,8 +532,16 @@ proc buildAttrTree(string $nodeName, string $attr, string $fullAttr)
             }
 
         } else if($isCompound && !$isMulti) {
-            int $collapsed = (`match "__open__" $parmName` == "__open__") ? 0 : 1;
+            int $collapsed = 0;
 
+            for ($category in $categories) 
+            {
+                if ($category == "default_close")
+                {
+                    $collapsed = 1;
+                }
+            }
+          
             float $color = 0.23;
 
             if (`match "__lv1__" $parmName` == "__lv1__") {


### PR DESCRIPTION
Distributes the logic to determine whether a folder should be collapsed or not from script AEhoudiniAssetTemplate.mel partly to the C++ side of the code. A tag is created for a folder on the C++ side and is later read in the .mel script.